### PR TITLE
[8] Refactor t_identity, t_book

### DIFF
--- a/src/main/java/com/myproject/doseoro/database/book.sql
+++ b/src/main/java/com/myproject/doseoro/database/book.sql
@@ -11,7 +11,6 @@ CREATE TABLE `t_book`
     `state`         JSON             NULL   DEFAULT NULL   COMMENT '책 상태',
     `trade_method`  VARCHAR(100)     NULL   DEFAULT NULL   COMMENT '책 거래 방법',
     `img`           JSON             NULL   DEFAULT NULL   COMMENT '책 이미지(표지, 내부 상태 사진)',
-    `like_count`    VARCHAR(100)     NULL   DEFAULT 0      COMMENT '해당 책을 "좋아요" 누른 사람들(즐겨찾기 추가한 사람들)',
     `sold`          TINYINT(1)       NULL   DEFAULT 0      COMMENT '해당 책이 팔렸는지 아닌지',
     `about`         VARCHAR(100)     NULL   DEFAULT NULL   COMMENT '해당 책에 대한 설명',
     `createdAt`     TIMESTAMP    NOT NULL   DEFAULT CURRENT_TIMESTAMP,

--- a/src/main/java/com/myproject/doseoro/database/identity.sql
+++ b/src/main/java/com/myproject/doseoro/database/identity.sql
@@ -9,7 +9,6 @@ CREATE TABLE `t_identity`
     `phone`                  VARCHAR(14)  NOT NULL COMMENT '유저 휴대폰번호',
     `forgot_pw_question`     VARCHAR(100) NOT NULL COMMENT '비밀번호 분실 시 인증을 위한 질문',
     `forgot_pw_answer`       VARCHAR(100) NOT NULL COMMENT '비밀번호 분실 시 인증을 위한 질문에 대한 답',
-    `liked`                  VARCHAR(100)     NULL COMMENT '좋아요 받은 개수',
     `location`               VARCHAR(100)     NULL COMMENT '유저가 사는 주소 전체',
     `dong`                   VARCHAR(10)      NULL COMMENT '유저가 사는 주소에서 동',
     `si`                     VARCHAR(10)      NULL COMMENT '유저가 사는 주소에서 시',
@@ -21,4 +20,4 @@ CREATE TABLE `t_identity`
     PRIMARY KEY (`seq`),
     UNIQUE KEY `uix-identity-id` (`id`)
 ) ENGINE = InnoDB
-  DEFAULT CHARSET = utf8mb4 COMMENT '회원가입';
+  DEFAULT CHARSET = utf8mb4 COMMENT '유저 정보';

--- a/src/main/java/com/myproject/doseoro/packages/identity/domain/Identity.java
+++ b/src/main/java/com/myproject/doseoro/packages/identity/domain/Identity.java
@@ -30,9 +30,6 @@ public class Identity {
     private String forgotPwAnswer;
 
     @Nullable
-    private String liked;
-
-    @Nullable
     private String location;
 
     @Nullable

--- a/src/main/java/com/myproject/doseoro/packages/identity/vo/IdentityMyPageVO.java
+++ b/src/main/java/com/myproject/doseoro/packages/identity/vo/IdentityMyPageVO.java
@@ -14,7 +14,6 @@ public class IdentityMyPageVO {
     private String name;
     private String nickName;
     private String phone;
-    private String liked;
     private String location;
     private String dong;
     private String si;
@@ -23,13 +22,12 @@ public class IdentityMyPageVO {
     private String snsId;
     private String updatedAt;
 
-    public IdentityMyPageVO(String id, String email, String name, String nickName, String phone, String liked, String location, String dong, String si, String dou, String provider, String snsId, String updatedAt) {
+    public IdentityMyPageVO(String id, String email, String name, String nickName, String phone, String location, String dong, String si, String dou, String provider, String snsId, String updatedAt) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.nickName = nickName;
         this.phone = phone;
-        this.liked = liked;
         this.location = location;
         this.dong = dong;
         this.si = si;
@@ -47,7 +45,6 @@ public class IdentityMyPageVO {
                 ", name='" + name + '\'' +
                 ", nickName='" + nickName + '\'' +
                 ", phone='" + phone + '\'' +
-                ", liked='" + liked + '\'' +
                 ", location='" + location + '\'' +
                 ", dong='" + dong + '\'' +
                 ", si='" + si + '\'' +
@@ -63,11 +60,11 @@ public class IdentityMyPageVO {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         IdentityMyPageVO that = (IdentityMyPageVO) o;
-        return Objects.equals(id, that.id) && Objects.equals(email, that.email) && Objects.equals(name, that.name) && Objects.equals(nickName, that.nickName) && Objects.equals(phone, that.phone) && Objects.equals(liked, that.liked) && Objects.equals(location, that.location) && Objects.equals(dong, that.dong) && Objects.equals(si, that.si) && Objects.equals(dou, that.dou) && Objects.equals(provider, that.provider) && Objects.equals(snsId, that.snsId) && Objects.equals(updatedAt, that.updatedAt);
+        return Objects.equals(id, that.id) && Objects.equals(email, that.email) && Objects.equals(name, that.name) && Objects.equals(nickName, that.nickName) && Objects.equals(phone, that.phone) && Objects.equals(location, that.location) && Objects.equals(dong, that.dong) && Objects.equals(si, that.si) && Objects.equals(dou, that.dou) && Objects.equals(provider, that.provider) && Objects.equals(snsId, that.snsId) && Objects.equals(updatedAt, that.updatedAt);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, email, name, nickName, phone, liked, location, dong, si, dou, provider, snsId, updatedAt);
+        return Objects.hash(id, email, name, nickName, phone, location, dong, si, dou, provider, snsId, updatedAt);
     }
 }


### PR DESCRIPTION
### 이슈
[8] Refactor t_identity, t_book

### 개요
* 테이블 리팩토링 실행

### 작업사항
* t_identity 에서 liked 컬럼을 지웠습니다. 
먼저 liked 컬럼의 의미는 해당 유저가 좋아요를 누른 책을 뜻하는 컬럼이었습니다.
이 컬럼을 지운 이유는 원래 해당 테이블의 의미는 오로지 유저의 정보만을 다루는 테이블이었기에 이 테이블과 어울리지않다고 판단하였습니다.

* t_book 컬럼에서 liked_count 컬럼을 지웠습니다.
먼저 liked_count 컬럼의 의미는 해당 책이 받은 좋아요 개수를 뜻합니다.
이 컬럼을 지운 이유는 오로지 책의 정보만을 다루는 이 테이블에는 어울리지 않는다고 판단하였습니다.

해당 책의 좋아요가 올라가거나 내려갈 때 마다 테이블을 업데이트 시키는 것 보다 연관된 컬럼끼리 묶어 테이블을 따로 만들어 관리하면 한눈에 보기 편하고 각 테이블이 고유에 원하는 목적을 지킬 수 있기에 SRP를 지킬 수 있기 때문이었습니다.
