### PR TITLE
레포지토리 구현 객체가 Query에 직접 의존한거 수정하기, 좀 더 의미가 명확하게 Query클래스 이름 수정

### DIFF
--- a/src/main/java/com/myproject/doseoro/adaptor/api/PageController.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/api/PageController.java
@@ -3,12 +3,12 @@ package com.myproject.doseoro.adaptor.api;
 import com.myproject.doseoro.adaptor.logger.Logging;
 import com.myproject.doseoro.application.book.handler.FindHomeDisplayingBooksCommandHandler;
 import com.myproject.doseoro.application.book.handler.GetLikedBooksByUserQuery;
-import com.myproject.doseoro.application.book.handler.SaleBoardQuery;
-import com.myproject.doseoro.application.identity.handler.MyPageQuery;
+import com.myproject.doseoro.application.book.handler.GetAllSaleBooksQuery;
+import com.myproject.doseoro.application.identity.handler.GetUserInformationQuery;
 import com.myproject.doseoro.domain.book.dto.GetLikedBooksByUserDtoResult;
-import com.myproject.doseoro.domain.book.dto.SaleBoardDtoResult;
+import com.myproject.doseoro.domain.book.dto.GetAllSaleBooksResult;
 import com.myproject.doseoro.domain.book.vo.*;
-import com.myproject.doseoro.domain.identity.dto.MyPageDtoResult;
+import com.myproject.doseoro.domain.identity.dto.GetUserInformationDtoResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,8 +21,8 @@ import java.util.List;
 public class PageController {
 
     private final FindHomeDisplayingBooksCommandHandler findHomeDisplayingBooksCommandHandler;
-    private final MyPageQuery myPageQuery;
-    private final SaleBoardQuery saleBoardQuery;
+    private final GetUserInformationQuery myPageQuery;
+    private final GetAllSaleBooksQuery saleBoardQuery;
     private final GetLikedBooksByUserQuery getLikedBooksByUserQuery;
 
 
@@ -51,7 +51,7 @@ public class PageController {
     @RequestMapping(value = "/mypage")
     public String myPage(Model model) {
 
-        MyPageDtoResult result = myPageQuery.query(voId);
+        GetUserInformationDtoResult result = myPageQuery.query(voId);
 
         model.addAttribute("user", result.getUser());
 
@@ -79,7 +79,7 @@ public class PageController {
     @RequestMapping(value = "/saleBoard")
     public String saleBoard(Model model) {
 
-        SaleBoardDtoResult bookList = saleBoardQuery.query(voId);
+        GetAllSaleBooksResult bookList = saleBoardQuery.query(voId);
         model.addAttribute("books", bookList);
 
         return "saleBoard";

--- a/src/main/java/com/myproject/doseoro/adaptor/api/book/controller/BookAPIcontroller.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/api/book/controller/BookAPIcontroller.java
@@ -2,16 +2,11 @@ package com.myproject.doseoro.adaptor.api.book.controller;
 
 import com.myproject.doseoro.adaptor.logger.Logging;
 import com.myproject.doseoro.application.book.handler.*;
-import com.myproject.doseoro.domain.book.dto.BookDetailDto;
-import com.myproject.doseoro.domain.book.dto.BookDetailDtoResult;
+import com.myproject.doseoro.domain.book.dto.GetAllBooksByBookIdDto;
+import com.myproject.doseoro.domain.book.dto.GetAllBooksByBookIdDtoResult;
 import com.myproject.doseoro.domain.book.vo.RegisterBookVO;
-import com.myproject.doseoro.domain.book.vo.BookVO;
 import com.myproject.doseoro.domain.book.vo.HomeDisplayedBookVO;
 import com.myproject.doseoro.domain.book.vo.BookHitVO;
-import com.myproject.doseoro.domain.identity.vo.IdentityMyPageVO;
-import com.myproject.doseoro.adaptor.infra.mybatis.book.BookMybatisRepository;
-import com.myproject.doseoro.adaptor.infra.mybatis.identity.IdentityMybatisRepository;
-import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +23,7 @@ public class BookAPIcontroller {
     private final FindHomeDisplayingBooksCommandHandler findHomeDisplayingBooksCommandHandler;
     private final HitLikeCommandHandler hitLikeCommandHandler;
     private final HitReLikeCommandHandler hitReLikeCommandHandler;
-    private final BookDetailPageQuery bookDetailPageQuery;
+    private final GetAllBooksByBookIdQuery bookDetailPageQuery;
 
     @Logging
     @PostMapping(value = "/book/register")
@@ -59,7 +54,7 @@ public class BookAPIcontroller {
     public ModelAndView bookDetailPage(ModelAndView model, @PathVariable String bookId) {
 
         try {
-            BookDetailDtoResult result = bookDetailPageQuery.query(new BookDetailDto(bookId));
+            GetAllBooksByBookIdDtoResult result = bookDetailPageQuery.query(new GetAllBooksByBookIdDto(bookId));
 
             model.setViewName("saleDetail");
             model.addObject("user", result.getUser());

--- a/src/main/java/com/myproject/doseoro/application/book/handler/GetAllBooksByBookIdQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/handler/GetAllBooksByBookIdQuery.java
@@ -1,13 +1,13 @@
 package com.myproject.doseoro.application.book.handler;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
-import com.myproject.doseoro.adaptor.infra.mybatis.book.BookMybatisRepository;
-import com.myproject.doseoro.adaptor.infra.mybatis.identity.IdentityMybatisRepository;
 import com.myproject.doseoro.application.abstraction.CommandQuery;
-import com.myproject.doseoro.domain.book.dto.BookDetailDto;
-import com.myproject.doseoro.domain.book.dto.BookDetailDtoResult;
+import com.myproject.doseoro.domain.book.abstraction.BookRepository;
+import com.myproject.doseoro.domain.book.dto.GetAllBooksByBookIdDto;
+import com.myproject.doseoro.domain.book.dto.GetAllBooksByBookIdDtoResult;
 import com.myproject.doseoro.domain.book.vo.BookHitVO;
 import com.myproject.doseoro.domain.book.vo.BookVO;
+import com.myproject.doseoro.domain.identity.abstraction.IdentityRepository;
 import com.myproject.doseoro.domain.identity.vo.IdentityMyPageVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,13 +16,13 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class BookDetailPageQuery implements CommandQuery<BookDetailDto, BookDetailDtoResult> {
-    private final BookMybatisRepository bookMybatisService;
-    private final IdentityMybatisRepository repository;
+public class GetAllBooksByBookIdQuery implements CommandQuery<GetAllBooksByBookIdDto, GetAllBooksByBookIdDtoResult> {
+    private final BookRepository bookMybatisService;
+    private final IdentityRepository repository;
     private final AccessUserSessionManager accessUserSessionManager;
 
     @Override
-    public BookDetailDtoResult query(BookDetailDto detailDTO) {
+    public GetAllBooksByBookIdDtoResult query(GetAllBooksByBookIdDto detailDTO) {
         BookVO book = bookMybatisService.findBookByBookId(detailDTO.getBookId());
         IdentityMyPageVO user = repository.findUserById(book.getOwnerId());
         String userId = accessUserSessionManager.extractUser();
@@ -30,6 +30,6 @@ public class BookDetailPageQuery implements CommandQuery<BookDetailDto, BookDeta
         List<BookHitVO> countLikedInTheBook = bookMybatisService.countLike(detailDTO.getBookId());
         String isLikeExisted = bookMybatisService.isBookLiked(userId, detailDTO.getBookId());
 
-        return new BookDetailDtoResult(book, user, countLikedInTheBook, isLikeExisted);
+        return new GetAllBooksByBookIdDtoResult(book, user, countLikedInTheBook, isLikeExisted);
     }
 }

--- a/src/main/java/com/myproject/doseoro/application/book/handler/GetAllSaleBooksQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/handler/GetAllSaleBooksQuery.java
@@ -1,8 +1,8 @@
 package com.myproject.doseoro.application.book.handler;
 
-import com.myproject.doseoro.adaptor.infra.mybatis.book.BookMybatisRepository;
 import com.myproject.doseoro.application.abstraction.CommandQuery;
-import com.myproject.doseoro.domain.book.dto.SaleBoardDtoResult;
+import com.myproject.doseoro.domain.book.abstraction.BookRepository;
+import com.myproject.doseoro.domain.book.dto.GetAllSaleBooksResult;
 import com.myproject.doseoro.domain.book.vo.FindAllBooksVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,14 +11,14 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class SaleBoardQuery implements CommandQuery<Void, SaleBoardDtoResult> {
+public class GetAllSaleBooksQuery implements CommandQuery<Void, GetAllSaleBooksResult> {
 
-    private final BookMybatisRepository bookMybatisService;
+    private final BookRepository bookMybatisService;
 
     @Override
-    public SaleBoardDtoResult query(Void unused) {
+    public GetAllSaleBooksResult query(Void unused) {
         List<FindAllBooksVO> bookList = bookMybatisService.findAllBooksForSaleBoard();
 
-        return new SaleBoardDtoResult(bookList);
+        return new GetAllSaleBooksResult(bookList);
     }
 }

--- a/src/main/java/com/myproject/doseoro/application/book/handler/GetLikedBooksByUserQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/handler/GetLikedBooksByUserQuery.java
@@ -1,8 +1,8 @@
 package com.myproject.doseoro.application.book.handler;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
-import com.myproject.doseoro.adaptor.infra.mybatis.book.BookMybatisRepository;
 import com.myproject.doseoro.application.abstraction.CommandQuery;
+import com.myproject.doseoro.domain.book.abstraction.BookRepository;
 import com.myproject.doseoro.domain.book.dto.GetLikedBooksByUserDtoResult;
 import com.myproject.doseoro.domain.book.vo.AllLikedBookVO;
 import com.myproject.doseoro.domain.book.vo.BookVO;
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class GetLikedBooksByUserQuery implements CommandQuery<Void, GetLikedBooksByUserDtoResult> {
 
-    private final BookMybatisRepository bookMybatisRepository;
+    private final BookRepository bookMybatisRepository;
     private final AccessUserSessionManager accessUserSessionManager;
 
     @Override

--- a/src/main/java/com/myproject/doseoro/application/identity/handler/GetUserInformationQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/identity/handler/GetUserInformationQuery.java
@@ -1,26 +1,26 @@
 package com.myproject.doseoro.application.identity.handler;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
-import com.myproject.doseoro.adaptor.infra.mybatis.identity.IdentityMybatisRepository;
 import com.myproject.doseoro.application.abstraction.CommandQuery;
-import com.myproject.doseoro.domain.identity.dto.MyPageDtoResult;
+import com.myproject.doseoro.domain.identity.abstraction.IdentityRepository;
+import com.myproject.doseoro.domain.identity.dto.GetUserInformationDtoResult;
 import com.myproject.doseoro.domain.identity.vo.IdentityMyPageVO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MyPageQuery implements CommandQuery<Void, MyPageDtoResult> {
+public class GetUserInformationQuery implements CommandQuery<Void, GetUserInformationDtoResult> {
 
     private final AccessUserSessionManager accessUserSessionManager;
-    private final IdentityMybatisRepository identityRepository;
+    private final IdentityRepository identityRepository;
 
     @Override
-    public MyPageDtoResult query(Void unused) {
+    public GetUserInformationDtoResult query(Void unused) {
         String userId = accessUserSessionManager.extractUser();
 
         IdentityMyPageVO user = identityRepository.findUserById(userId);
 
-        return new MyPageDtoResult(user);
+        return new GetUserInformationDtoResult(user);
     }
 }

--- a/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllBooksByBookIdDto.java
+++ b/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllBooksByBookIdDto.java
@@ -3,10 +3,10 @@ package com.myproject.doseoro.domain.book.dto;
 import lombok.Getter;
 
 @Getter
-public class BookDetailDto {
+public class GetAllBooksByBookIdDto {
     private final String bookId;
 
-    public BookDetailDto(String bookId) {
+    public GetAllBooksByBookIdDto(String bookId) {
         this.bookId = bookId;
     }
 }

--- a/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllBooksByBookIdDtoResult.java
+++ b/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllBooksByBookIdDtoResult.java
@@ -3,16 +3,15 @@ package com.myproject.doseoro.domain.book.dto;
 import com.myproject.doseoro.domain.book.vo.BookHitVO;
 import com.myproject.doseoro.domain.book.vo.BookVO;
 import com.myproject.doseoro.domain.identity.vo.IdentityMyPageVO;
-import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
-public class BookDetailDtoResult {
+public class GetAllBooksByBookIdDtoResult {
     private final BookVO book;
 
-    public BookDetailDtoResult(BookVO book, IdentityMyPageVO user, List<BookHitVO> countLikedInTheBook, String isLikeExisted) {
+    public GetAllBooksByBookIdDtoResult(BookVO book, IdentityMyPageVO user, List<BookHitVO> countLikedInTheBook, String isLikeExisted) {
         this.book = book;
         this.user = user;
         this.countLikedInTheBook = countLikedInTheBook;

--- a/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllSaleBooksResult.java
+++ b/src/main/java/com/myproject/doseoro/domain/book/dto/GetAllSaleBooksResult.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 import java.util.List;
 
 @Getter
-public class SaleBoardDtoResult {
+public class GetAllSaleBooksResult {
     private final List<FindAllBooksVO> bookList;
 
-    public SaleBoardDtoResult(List<FindAllBooksVO> bookList) {
+    public GetAllSaleBooksResult(List<FindAllBooksVO> bookList) {
         this.bookList = bookList;
     }
 }

--- a/src/main/java/com/myproject/doseoro/domain/identity/dto/GetUserInformationDtoResult.java
+++ b/src/main/java/com/myproject/doseoro/domain/identity/dto/GetUserInformationDtoResult.java
@@ -4,8 +4,8 @@ import com.myproject.doseoro.domain.identity.vo.IdentityMyPageVO;
 import lombok.Getter;
 
 @Getter
-public class MyPageDtoResult {
-    public MyPageDtoResult(IdentityMyPageVO user) {
+public class GetUserInformationDtoResult {
+    public GetUserInformationDtoResult(IdentityMyPageVO user) {
         this.user = user;
     }
 


### PR DESCRIPTION
### 이슈
[44] 레포지토리 구현 객체가 Query에 직접 의존한거 수정하기, 좀 더 의미가 명확하게 Query클래스 이름 수정

### 개요
레포지토리 구현 객체가 Query에 직접 의존한거 수정하기, 좀 더 의미가 명확하게 Query클래스 이름 수정

### 작업사항
 * 구현체 의존성 체크
 * 클래스 이름 의미 명확성 체크 (+ 클래스 이름에 따른 사이드 이팩트로 dto 이름도 변경)
 