### PR TITLE
read-only Query 객체들 패키지 정리

### DIFF
--- a/src/main/java/com/myproject/doseoro/adaptor/api/PageController.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/api/PageController.java
@@ -2,10 +2,10 @@ package com.myproject.doseoro.adaptor.api;
 
 import com.myproject.doseoro.adaptor.logger.Logging;
 import com.myproject.doseoro.application.book.handler.FindHomeDisplayingBooksCommandHandler;
-import com.myproject.doseoro.application.book.handler.GetLikedBooksByUserQuery;
-import com.myproject.doseoro.application.book.handler.GetAllSaleBooksQuery;
+import com.myproject.doseoro.application.book.readmodel.GetLikedBooksByUserQuery;
+import com.myproject.doseoro.application.book.readmodel.GetAllSaleBooksQuery;
 import com.myproject.doseoro.application.book.vo.HomeDisplayedBookVO;
-import com.myproject.doseoro.application.identity.handler.GetUserInformationQuery;
+import com.myproject.doseoro.application.identity.readmodel.GetUserInformationQuery;
 import com.myproject.doseoro.application.book.dto.GetLikedBooksByUserDtoResult;
 import com.myproject.doseoro.application.book.dto.GetAllSaleBooksResult;
 import com.myproject.doseoro.application.identity.dto.GetUserInformationDtoResult;

--- a/src/main/java/com/myproject/doseoro/adaptor/api/book/controller/BookAPIcontroller.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/api/book/controller/BookAPIcontroller.java
@@ -4,6 +4,7 @@ import com.myproject.doseoro.adaptor.logger.Logging;
 import com.myproject.doseoro.application.book.handler.*;
 import com.myproject.doseoro.application.book.dto.GetAllBooksByBookIdDto;
 import com.myproject.doseoro.application.book.dto.GetAllBooksByBookIdDtoResult;
+import com.myproject.doseoro.application.book.readmodel.GetAllBooksByBookIdQuery;
 import com.myproject.doseoro.application.book.vo.RegisterBookVO;
 import com.myproject.doseoro.application.book.vo.HomeDisplayedBookVO;
 import com.myproject.doseoro.application.book.vo.BookHitVO;

--- a/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQuery.java
@@ -1,4 +1,4 @@
-package com.myproject.doseoro.application.book.handler;
+package com.myproject.doseoro.application.book.readmodel;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
 import com.myproject.doseoro.application.abstraction.CommandQuery;

--- a/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllSaleBooksQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllSaleBooksQuery.java
@@ -1,4 +1,4 @@
-package com.myproject.doseoro.application.book.handler;
+package com.myproject.doseoro.application.book.readmodel;
 
 import com.myproject.doseoro.application.abstraction.CommandQuery;
 import com.myproject.doseoro.application.abstraction.BookRepository;

--- a/src/main/java/com/myproject/doseoro/application/book/readmodel/GetLikedBooksByUserQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/readmodel/GetLikedBooksByUserQuery.java
@@ -1,4 +1,4 @@
-package com.myproject.doseoro.application.book.handler;
+package com.myproject.doseoro.application.book.readmodel;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
 import com.myproject.doseoro.application.abstraction.CommandQuery;

--- a/src/main/java/com/myproject/doseoro/application/identity/readmodel/GetUserInformationQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/identity/readmodel/GetUserInformationQuery.java
@@ -1,4 +1,4 @@
-package com.myproject.doseoro.application.identity.handler;
+package com.myproject.doseoro.application.identity.readmodel;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
 import com.myproject.doseoro.application.abstraction.CommandQuery;


### PR DESCRIPTION
### 이슈
[49] read-only Query 객체들 패키지 정리

### 개요
read-only Query 객체들 패키지 정리

### 작업사항
* book, identity 각 도메인(domain 패키지 x)에 readmodel 패키지를 만들어 query 클래스들을 넣었습니다.
