### PR TITLE
CreateUserIdentityCommandHandlerTest 테스트를 SpringBootTest 사용하지 않고 테스트작성하기

### DIFF
--- a/src/test/java/com/myproject/doseoro/application/identity/handler/CreateUserIdentityCommandHandlerTest.java
+++ b/src/test/java/com/myproject/doseoro/application/identity/handler/CreateUserIdentityCommandHandlerTest.java
@@ -1,42 +1,42 @@
 package com.myproject.doseoro.application.identity.handler;
 
 import com.myproject.doseoro.adaptor.global.error.exception.BusinessException;
-import com.myproject.doseoro.adaptor.infra.dao.IdentityDao;
 import com.myproject.doseoro.adaptor.infra.mybatis.identity.IdentityMybatisRepository;
 import com.myproject.doseoro.application.identity.vo.SignUpVO;
 import com.myproject.doseoro.identity.SignUpVOFixture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.password.PasswordEncoder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class CreateUserIdentityCommandHandlerTest {
 
-    @Autowired
-    private IdentityDao dao;
-    @Autowired
-    private PasswordEncoder passwordEncoder;
+    @InjectMocks
+    CreateUserIdentityCommandHandler sut;
+    @Mock
+    private IdentityMybatisRepository repository;
 
     @Test
     @DisplayName("유저인증 정보가 존재하지 않는다면 인증 정보를 생성한다.")
     @Transactional // 테스트 완료 후 rollback
     public void commandHandler() {
         // given
-        IdentityMybatisRepository repository = new IdentityMybatisRepository(dao, passwordEncoder);
         SignUpVO user = SignUpVOFixture.signUpVO;
 
-        CreateUserIdentityCommandHandler sut = new CreateUserIdentityCommandHandler(repository);
-
+        when(repository.existEmail(user.getEmail())).thenReturn(false);
         // when
         sut.handle(user);
 
         // then
+        when(repository.findUser(user.getEmail())).thenReturn(user);
         SignUpVO actual = repository.findUser(user.getEmail());
 
         assertThat(actual).isNotNull();
@@ -53,15 +53,14 @@ class CreateUserIdentityCommandHandlerTest {
     @Transactional
     public void errorTest() {
         // given
-        IdentityMybatisRepository repository = new IdentityMybatisRepository(dao, passwordEncoder);
-
         SignUpVO user = SignUpVOFixture.signUpVO;
+        when(repository.existEmail(user.getEmail())).thenReturn(true);
         repository.signUp(user);
-
-        CreateUserIdentityCommandHandler sut = new CreateUserIdentityCommandHandler(repository);
 
         // when
         // then
-        Assertions.assertThrows(BusinessException.class, () -> sut.handle(user));
+        Assertions.assertThrows(BusinessException.class,
+                () -> sut.handle(user),
+                "Email is Duplicated");
     }
 }


### PR DESCRIPTION
### 이슈
[85] CreateUserIdentityCommandHandlerTest 테스트를 SpringBootTest 사용하지 않고 테스트작성하기

### 개요
CreateUserIdentityCommandHandlerTest 테스트를 SpringBootTest 사용하지 않고 테스트작성하기

### 작업사항
* CreateUserIdentityCommandHandlerTest 테스트를 SpringBootTest 사용하지 않고 테스트작성

### 테스트 사항
* 유저인증 정보가 존재하지 않는다면 인증 정보를 생성한다.
* 같은 유저 정보가 있을 경우 에러를 반환한다.