### PR TITLE
RemoveUserSessionCommandHandlerTest테스트를 SpringBootTest 사용하지 않고 테스트하기

### DIFF
--- a/src/test/java/com/myproject/doseoro/application/identity/handler/RemoveUserSessionCommandHandlerTest.java
+++ b/src/test/java/com/myproject/doseoro/application/identity/handler/RemoveUserSessionCommandHandlerTest.java
@@ -1,38 +1,38 @@
 package com.myproject.doseoro.application.identity.handler;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
-import com.myproject.doseoro.application.identity.handler.RemoveUserSessionCommandHandler;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
-@SpringBootTest
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
 class RemoveUserSessionCommandHandlerTest {
 
-    MockHttpServletRequest servletRequest;
-    AccessUserSessionManager userSessionManager;
-
-    @BeforeEach
-    void setUp() {
-        MockHttpSession httpSession = new MockHttpSession();
-        servletRequest = new MockHttpServletRequest();
-        servletRequest.setSession(httpSession);
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
-        userSessionManager = new AccessUserSessionManager(servletRequest);
-    }
+    @Mock
+    RemoveUserSessionCommandHandler removeUserSessionCommandHandler;
+    @Mock
+    private MockHttpServletRequest servletRequest;
+    @Mock
+    private AccessUserSessionManager userSessionManager;
+    @Mock
+    private MockHttpSession httpSession;
 
     @Test
     @DisplayName("로그인 된 유저의 세션을 지우면서 로그아웃 시킬 수 있다.")
     @Transactional
     void commandHandler() {
 
-        RemoveUserSessionCommandHandler removeUserSessionCommandHandler = new RemoveUserSessionCommandHandler();
+        servletRequest.setSession(httpSession);
+        userSessionManager = new AccessUserSessionManager(servletRequest);
+
+        when(servletRequest.getSession()).thenReturn(httpSession);
         servletRequest.getSession().setAttribute("test-session", "test");
 
         removeUserSessionCommandHandler.handle(servletRequest.getSession());


### PR DESCRIPTION
### 이슈
[86] RemoveUserSessionCommandHandlerTest테스트를 SpringBootTest 사용하지 않고 테스트하기

### 개요
RemoveUserSessionCommandHandlerTest테스트를 SpringBootTest 사용하지 않고 테스트하기

### 작업사항
* RemoveUserSessionCommandHandlerTest테스트를 SpringBootTest 사용하지 않고 테스트하기

### 테스트 사항
* 로그인 된 유저의 세션을 지우면서 로그아웃 시킬 수 있다.