### PR TITLE
mybatis 라이브러리 의존성 제거

### DIFF
--- a/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
@@ -1,5 +1,6 @@
 package com.myproject.doseoro.adaptor.infra.dao;
 
+import com.myproject.doseoro.application.book.dto.BookReHitDto;
 import com.myproject.doseoro.application.book.vo.AllLikedBookVO;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
@@ -12,9 +13,9 @@ import org.apache.ibatis.annotations.Param;
 
 public interface BookDao {
 
-    void registerBook(@Param("vo") RegisterBookVO vo);
+    void registerBook(RegisterBookVO vo);
 
-    void registerDonationBook(@Param("vo") RegisterBookVO vo);
+    void registerDonationBook(RegisterBookVO vo);
 
     BookVO findBookByBookId(String bookId);
 
@@ -22,13 +23,11 @@ public interface BookDao {
 
     List<FindAllBooksVO> findAllBooksForSaleBoard();
 
-    void hitLike(@Param("vo") BookHitVO vo);
+    void hitLike(BookHitVO vo);
 
-    void hitReLikeWhenUnLiked(@Param("userId") String userId, @Param("bookId") String bookId,
-        @Param("isLiked") String isLiked);
+    void hitReLikeWhenUnLiked(BookReHitDto dto);
 
-    void hitReLikeWhenLiked(@Param("userId") String userId, @Param("bookId") String bookId,
-        @Param("isLiked") String isLiked);
+    void hitReLikeWhenLiked(BookReHitDto dto);
 
     List<BookHitVO> isLikedByUserIdAndBookId(@Param("userId") String userId,
         @Param("bookId") String bookId);

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
@@ -6,10 +6,10 @@ import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
 import com.myproject.doseoro.application.book.vo.FindAllBooksVO;
 import com.myproject.doseoro.application.book.vo.FindAllLikedBookVO;
+import com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo;
 import com.myproject.doseoro.application.book.vo.HomeDisplayedBookVO;
 import com.myproject.doseoro.application.book.vo.RegisterBookVO;
 import java.util.List;
-import org.apache.ibatis.annotations.Param;
 
 public interface BookDao {
 
@@ -33,11 +33,11 @@ public interface BookDao {
 
     List<BookHitVO> countLike(String bookId);
 
-    String isBookLiked(@Param("userId") String userId, @Param("bookId") String bookId);
+    String isBookLiked(FindIfBookIsLikedVo vo);
 
     List<FindAllLikedBookVO> FindAllLikedBookByUserId(String userId);
 
     List<AllLikedBookVO> allLikedBook(String userId);
 
-    void hitBook(@Param("bookId") String bookId);
+    void hitBook(String bookId);
 }

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/dao/BookDao.java
@@ -29,8 +29,7 @@ public interface BookDao {
 
     void hitReLikeWhenLiked(BookReHitDto dto);
 
-    List<BookHitVO> isLikedByUserIdAndBookId(@Param("userId") String userId,
-        @Param("bookId") String bookId);
+    List<BookHitVO> isLikedByUserIdAndBookId(BookHitVO vo);
 
     List<BookHitVO> countLike(String bookId);
 

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/dao/IdentityDao.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/dao/IdentityDao.java
@@ -4,7 +4,6 @@ import com.myproject.doseoro.application.identity.vo.AccessUserVO;
 import com.myproject.doseoro.application.identity.vo.IdentityMyPageVO;
 import com.myproject.doseoro.application.identity.vo.LogInVO;
 import com.myproject.doseoro.application.identity.vo.SignUpVO;
-import org.apache.ibatis.annotations.Param;
 
 public interface IdentityDao {
 
@@ -16,7 +15,7 @@ public interface IdentityDao {
 
     SignUpVO findUser(String email);
 
-    LogInVO loginCheck(@Param("email") String email);
+    LogInVO loginCheck(String email);
 
     boolean signUp(SignUpVO user);
 }

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
@@ -8,6 +8,7 @@ import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
 import com.myproject.doseoro.application.book.vo.FindAllBooksVO;
 import com.myproject.doseoro.application.book.vo.FindAllLikedBookVO;
+import com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo;
 import com.myproject.doseoro.application.book.vo.HomeDisplayedBookVO;
 import com.myproject.doseoro.application.book.vo.RegisterBookVO;
 import java.util.List;
@@ -73,8 +74,8 @@ public class BookMybatisRepository implements BookRepository {
     }
 
     @Override
-    public String isBookLiked(String userId, String bookId) {
-        return dao.isBookLiked(userId, bookId);
+    public String isBookLiked(FindIfBookIsLikedVo vo) {
+        return dao.isBookLiked(vo);
     }
 
     @Override

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
@@ -63,8 +63,8 @@ public class BookMybatisRepository implements BookRepository {
     }
 
     @Override
-    public List<BookHitVO> isLikedByUserIdAndBookId(String userId, String bookId) {
-        return dao.isLikedByUserIdAndBookId(userId, bookId);
+    public List<BookHitVO> isLikedByUserIdAndBookId(BookHitVO vo) {
+        return dao.isLikedByUserIdAndBookId(vo);
     }
 
     @Override

--- a/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
+++ b/src/main/java/com/myproject/doseoro/adaptor/infra/mybatis/book/BookMybatisRepository.java
@@ -2,6 +2,7 @@ package com.myproject.doseoro.adaptor.infra.mybatis.book;
 
 import com.myproject.doseoro.adaptor.infra.dao.BookDao;
 import com.myproject.doseoro.application.abstraction.BookRepository;
+import com.myproject.doseoro.application.book.dto.BookReHitDto;
 import com.myproject.doseoro.application.book.vo.AllLikedBookVO;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
@@ -50,15 +51,15 @@ public class BookMybatisRepository implements BookRepository {
     }
 
     @Override
-    public void hitReLikeWhenLiked(String userId, String bookId, String isLiked) {
+    public void hitReLikeWhenLiked(BookReHitDto dto) {
         // 좋아요 눌러져 있을 때
-        dao.hitReLikeWhenLiked(userId, bookId, isLiked);
+        dao.hitReLikeWhenLiked(dto);
     }
 
     @Override
-    public void hitReLikeWhenUnLiked(String userId, String bookId, String isLiked) {
+    public void hitReLikeWhenUnLiked(BookReHitDto dto) {
         // 좋아요 안 눌러져 있을 때
-        dao.hitReLikeWhenUnLiked(userId, bookId, isLiked);
+        dao.hitReLikeWhenUnLiked(dto);
     }
 
     @Override

--- a/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
+++ b/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
@@ -6,6 +6,7 @@ import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
 import com.myproject.doseoro.application.book.vo.FindAllBooksVO;
 import com.myproject.doseoro.application.book.vo.FindAllLikedBookVO;
+import com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo;
 import com.myproject.doseoro.application.book.vo.HomeDisplayedBookVO;
 import com.myproject.doseoro.application.book.vo.RegisterBookVO;
 import java.util.List;
@@ -32,7 +33,7 @@ public interface BookRepository {
 
     public List<BookHitVO> countLike(String bookId);
 
-    public String isBookLiked(String userId, String bookId);
+    public String isBookLiked(FindIfBookIsLikedVo vo);
 
     List<FindAllLikedBookVO> FindAllLikedBookByUserId(String userId);
 

--- a/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
+++ b/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
@@ -1,5 +1,6 @@
 package com.myproject.doseoro.application.abstraction;
 
+import com.myproject.doseoro.application.book.dto.BookReHitDto;
 import com.myproject.doseoro.application.book.vo.AllLikedBookVO;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
@@ -23,9 +24,9 @@ public interface BookRepository {
 
     public void hitLike(BookHitVO vo);
 
-    public void hitReLikeWhenLiked(String userId, String bookId, String isLiked);
+    public void hitReLikeWhenLiked(BookReHitDto dto);
 
-    public void hitReLikeWhenUnLiked(String userId, String bookId, String isLiked);
+    public void hitReLikeWhenUnLiked(BookReHitDto dto);
 
     public List<BookHitVO> isLikedByUserIdAndBookId(String userId, String bookId);
 

--- a/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
+++ b/src/main/java/com/myproject/doseoro/application/abstraction/BookRepository.java
@@ -28,7 +28,7 @@ public interface BookRepository {
 
     public void hitReLikeWhenUnLiked(BookReHitDto dto);
 
-    public List<BookHitVO> isLikedByUserIdAndBookId(String userId, String bookId);
+    public List<BookHitVO> isLikedByUserIdAndBookId(BookHitVO vo);
 
     public List<BookHitVO> countLike(String bookId);
 

--- a/src/main/java/com/myproject/doseoro/application/book/dto/BookReHitDto.java
+++ b/src/main/java/com/myproject/doseoro/application/book/dto/BookReHitDto.java
@@ -1,0 +1,13 @@
+package com.myproject.doseoro.application.book.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BookReHitDto {
+
+    private final String userId;
+    private final String bookId;
+    private final String isLiked;
+}

--- a/src/main/java/com/myproject/doseoro/application/book/handler/HitReLikeCommandHandler.java
+++ b/src/main/java/com/myproject/doseoro/application/book/handler/HitReLikeCommandHandler.java
@@ -1,13 +1,13 @@
 package com.myproject.doseoro.application.book.handler;
 
 import com.myproject.doseoro.adaptor.logger.Logging;
-import com.myproject.doseoro.application.abstraction.CommandHandler;
 import com.myproject.doseoro.application.abstraction.BookRepository;
+import com.myproject.doseoro.application.abstraction.CommandHandler;
+import com.myproject.doseoro.application.book.dto.BookReHitDto;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,19 +19,23 @@ public class HitReLikeCommandHandler implements CommandHandler<BookHitVO, BookHi
     @Override
     public BookHitVO handle(BookHitVO vo) {
         List<BookHitVO> found = repository.isLikedByUserIdAndBookId(vo.getUserId(), vo.getBookId());
-        if (found.size() == 0) return vo;
+        if (found.isEmpty()) {
+            return vo;
+        }
         // 좋아요 요청 들어오면 유저 이력 유무 검사.
         // 해당 객체에 좋아요 누른 이력이 없었으면 객체 그대로 리턴
 
-        if (!found.get(0).getId().isEmpty()) { // 유저의 좋아요 이력이 있을 때
+        BookReHitDto dto = new BookReHitDto(found.get(0).getUserId(), found.get(0).getBookId(),
+            found.get(0).getIsLiked());
 
+        if (!found.get(0).getId().isEmpty()) { // 유저의 좋아요 이력이 있을 때
             if (found.get(0).getIsLiked().equals("f")) {
                 // 좋아요 안 눌러져 있을때
-                repository.hitReLikeWhenUnLiked(found.get(0).getUserId(), found.get(0).getBookId(), found.get(0).getIsLiked());
+                repository.hitReLikeWhenUnLiked(dto);
 
             } else {
                 // 좋아요 눌러져 있을때
-                repository.hitReLikeWhenLiked(found.get(0).getUserId(), found.get(0).getBookId(), found.get(0).getIsLiked());
+                repository.hitReLikeWhenLiked(dto);
             }
             return found.get(0);
         }

--- a/src/main/java/com/myproject/doseoro/application/book/handler/HitReLikeCommandHandler.java
+++ b/src/main/java/com/myproject/doseoro/application/book/handler/HitReLikeCommandHandler.java
@@ -18,7 +18,7 @@ public class HitReLikeCommandHandler implements CommandHandler<BookHitVO, BookHi
     @Logging
     @Override
     public BookHitVO handle(BookHitVO vo) {
-        List<BookHitVO> found = repository.isLikedByUserIdAndBookId(vo.getUserId(), vo.getBookId());
+        List<BookHitVO> found = repository.isLikedByUserIdAndBookId(vo);
         if (found.isEmpty()) {
             return vo;
         }

--- a/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllInformationOfTheBookByBookIdQuery.java
+++ b/src/main/java/com/myproject/doseoro/application/book/readmodel/GetAllInformationOfTheBookByBookIdQuery.java
@@ -1,35 +1,45 @@
 package com.myproject.doseoro.application.book.readmodel;
 
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
-import com.myproject.doseoro.application.abstraction.CommandQuery;
 import com.myproject.doseoro.application.abstraction.BookRepository;
+import com.myproject.doseoro.application.abstraction.CommandQuery;
+import com.myproject.doseoro.application.abstraction.IdentityRepository;
 import com.myproject.doseoro.application.book.dto.GetAllInformationOfTheBookByBookIdDto;
 import com.myproject.doseoro.application.book.dto.GetAllInformationOfTheBookByBookIdDtoResult;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
-import com.myproject.doseoro.application.abstraction.IdentityRepository;
+import com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo;
 import com.myproject.doseoro.application.identity.vo.IdentityMyPageVO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
-public class GetAllInformationOfTheBookByBookIdQuery implements CommandQuery<GetAllInformationOfTheBookByBookIdDto, GetAllInformationOfTheBookByBookIdDtoResult> {
+public class GetAllInformationOfTheBookByBookIdQuery implements
+    CommandQuery<GetAllInformationOfTheBookByBookIdDto, GetAllInformationOfTheBookByBookIdDtoResult> {
+
     private final BookRepository bookMybatisService;
     private final IdentityRepository repository;
     private final AccessUserSessionManager accessUserSessionManager;
 
     @Override
-    public GetAllInformationOfTheBookByBookIdDtoResult query(GetAllInformationOfTheBookByBookIdDto detailDTO) {
+    public GetAllInformationOfTheBookByBookIdDtoResult query(
+        GetAllInformationOfTheBookByBookIdDto detailDTO) {
+
         BookVO book = bookMybatisService.findBookByBookId(detailDTO.getBookId());
         IdentityMyPageVO user = repository.findUserById(book.getOwnerId());
         String userId = accessUserSessionManager.extractUser();
 
         List<BookHitVO> countLikedInTheBook = bookMybatisService.countLike(detailDTO.getBookId());
-        String isLikeExisted = bookMybatisService.isBookLiked(userId, detailDTO.getBookId()); // 이 페이지를 열어본 유저가 책에 좋아요를 눌렀는지 검사 (여부에 따라 하트 색깔 바뀜)
 
-        return new GetAllInformationOfTheBookByBookIdDtoResult(book, user, countLikedInTheBook, isLikeExisted);
+        // 이 페이지를 열어본 유저가 책에 좋아요를 눌렀는지 검사 (여부에 따라 하트 색깔 바뀜)
+        String isLikeExisted = bookMybatisService.isBookLiked(
+            new FindIfBookIsLikedVo(userId, detailDTO.getBookId())
+        );
+
+        return new GetAllInformationOfTheBookByBookIdDtoResult(
+            book, user, countLikedInTheBook, isLikeExisted
+        );
     }
 }

--- a/src/main/java/com/myproject/doseoro/application/book/vo/FindIfBookIsLikedVo.java
+++ b/src/main/java/com/myproject/doseoro/application/book/vo/FindIfBookIsLikedVo.java
@@ -1,0 +1,14 @@
+package com.myproject.doseoro.application.book.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode
+public class FindIfBookIsLikedVo {
+
+    private final String userId;
+    private final String bookId;
+}

--- a/src/main/resources/mybatis/mapper/BookDao.xml
+++ b/src/main/resources/mybatis/mapper/BookDao.xml
@@ -20,18 +20,18 @@
      img,
      about,
      owner_id)
-    VALUES (#{vo.id},
-            #{vo.postmessage},
-            #{vo.title},
-            #{vo.price},
-            #{vo.author},
-            #{vo.publisher},
-            #{vo.checkCategory, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.checkState, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.dealRoot},
-            #{vo.images, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.about},
-            #{vo.ownerId});
+    VALUES (#{id},
+            #{postmessage},
+            #{title},
+            #{price},
+            #{author},
+            #{publisher},
+            #{checkCategory, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{checkState, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{dealRoot},
+            #{images, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{about},
+            #{ownerId});
   </insert>
 
   <!--   무료나눔 책 등록    -->
@@ -49,17 +49,17 @@
      img,
      about,
      owner_id)
-    VALUES (#{vo.id},
-            #{vo.postmessage},
-            #{vo.title},
-            #{vo.author},
-            #{vo.publisher},
-            #{vo.checkCategory, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.checkState, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.dealRoot},
-            #{vo.images, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
-            #{vo.about},
-            #{vo.ownerId});
+    VALUES (#{id},
+            #{postmessage},
+            #{title},
+            #{author},
+            #{publisher},
+            #{checkCategory, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{checkState, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{dealRoot},
+            #{images, typeHandler=com.myproject.doseoro.adaptor.infra.mybatis.util.JsonTypeHandler},
+            #{about},
+            #{ownerId});
   </insert>
 
   <!--    책의 id로 책 찾기    -->
@@ -166,9 +166,9 @@
      identity_id,
      book_id,
      is_liked)
-    VALUES (#{vo.id},
-            #{vo.userId},
-            #{vo.bookId},
+    VALUES (#{id},
+            #{userId},
+            #{bookId},
             't');
   </insert>
 
@@ -192,7 +192,7 @@
 
 
   <!--    해당 유저가 다시 좋아요 눌렀을 때 'is_liked' 가 't'면 'f'로 업데이트    -->
-  <update id="hitReLikeWhenLiked" parameterType="String">
+  <update id="hitReLikeWhenLiked">
     UPDATE t_book_like
     SET is_liked = 'f'
     WHERE identity_id = #{userId}
@@ -200,7 +200,7 @@
   </update>
 
   <!--    해당 유저가 다시 좋아요 눌렀을 때 'is_liked' 가 'f'면 't'로 업데이트    -->
-  <update id="hitReLikeWhenUnLiked" parameterType="String">
+  <update id="hitReLikeWhenUnLiked">
     UPDATE t_book_like
     SET is_liked = 't'
     WHERE identity_id = #{userId}

--- a/src/main/resources/mybatis/mapper/BookDao.xml
+++ b/src/main/resources/mybatis/mapper/BookDao.xml
@@ -221,7 +221,8 @@
   </select>
 
   <!--    좋아요 여부    -->
-  <select id="isBookLiked" resultType="String" parameterType="String">
+  <select id="isBookLiked" resultType="String"
+    parameterType="com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo">
     SELECT identity_id,
            book_id,
            is_liked

--- a/src/test/java/com/myproject/doseoro/application/book/handler/HitLikeCommandHandlerTest.java
+++ b/src/test/java/com/myproject/doseoro/application/book/handler/HitLikeCommandHandlerTest.java
@@ -29,8 +29,7 @@ class HitLikeCommandHandlerTest {
 
         // when
         sut.handle(vo);
-        List<BookHitVO> actual = bookRepository.isLikedByUserIdAndBookId(vo.getUserId(),
-            vo.getBookId());
+        List<BookHitVO> actual = bookRepository.isLikedByUserIdAndBookId(vo);
 
         // then
         assertThat(actual).isNotNull();
@@ -51,8 +50,7 @@ class HitLikeCommandHandlerTest {
         // when
         bookRepository.hitLike(likeObject);
         sut.handle(likeObject);
-        List<BookHitVO> actual = bookRepository.isLikedByUserIdAndBookId(likeObject.getUserId(),
-            likeObject.getBookId());
+        List<BookHitVO> actual = bookRepository.isLikedByUserIdAndBookId(likeObject);
 
         // then
         assertThat(actual.get(0).getIsLiked()).isEqualTo("f");

--- a/src/test/java/com/myproject/doseoro/application/book/handler/HitLikeCommandHandlerTest.java
+++ b/src/test/java/com/myproject/doseoro/application/book/handler/HitLikeCommandHandlerTest.java
@@ -36,6 +36,7 @@ class HitLikeCommandHandlerTest {
         assertThat(actual).isNotNull();
         assertThat(actual.get(0).getUserId()).isEqualTo("1212");
         assertThat(actual.get(0).getBookId()).isEqualTo("2525");
+        assertThat(actual.get(0).getIsLiked()).isEqualTo("t");
     }
 
     @Test

--- a/src/test/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQueryTest.java
+++ b/src/test/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQueryTest.java
@@ -1,5 +1,8 @@
 package com.myproject.doseoro.application.book.readmodel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import com.myproject.doseoro.adaptor.global.util.session.AccessUserSessionManager;
 import com.myproject.doseoro.application.abstraction.BookRepository;
 import com.myproject.doseoro.application.abstraction.IdentityRepository;
@@ -7,22 +10,19 @@ import com.myproject.doseoro.application.book.dto.GetAllInformationOfTheBookByBo
 import com.myproject.doseoro.application.book.dto.GetAllInformationOfTheBookByBookIdDtoResult;
 import com.myproject.doseoro.application.book.vo.BookHitVO;
 import com.myproject.doseoro.application.book.vo.BookVO;
+import com.myproject.doseoro.application.book.vo.FindIfBookIsLikedVo;
 import com.myproject.doseoro.application.identity.vo.IdentityMyPageVO;
 import com.myproject.doseoro.book.BookHitVOFixture;
 import com.myproject.doseoro.book.BookVOFixture;
 import com.myproject.doseoro.identity.IdentityMyPageVOFixture;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GetAllBooksByBookIdQueryTest {
@@ -52,13 +52,20 @@ class GetAllBooksByBookIdQueryTest {
         List<BookHitVO> countLikedInTheBook = new ArrayList<>();
         countLikedInTheBook.add(bookLikedList);
 
+//        FindIfBookIsLikedVo vo = new FindIfBookIsLikedVo("12312315256787", "777");
+
         when(bookMybatisService.findBookByBookId("777")).thenReturn(registeredBook1);
-        when(identityMybatisRepository.findUserById("12312315256787")).thenReturn(registeredIdentity);
+        when(identityMybatisRepository.findUserById("12312315256787")).thenReturn(
+            registeredIdentity);
         when(accessUserSessionManager.extractUser()).thenReturn("12312315256787");
         when(bookMybatisService.countLike("777")).thenReturn(countLikedInTheBook);
-        when(bookMybatisService.isBookLiked("12312315256787", "777")).thenReturn("true");
 
-        GetAllInformationOfTheBookByBookIdDtoResult actual = getAllInformationOfTheBookByBookIdQuery.query(new GetAllInformationOfTheBookByBookIdDto("777"));
+        when(bookMybatisService.isBookLiked(
+            new FindIfBookIsLikedVo("12312315256787", "777"))
+        ).thenReturn("true");
+
+        GetAllInformationOfTheBookByBookIdDtoResult actual = getAllInformationOfTheBookByBookIdQuery.query(
+            new GetAllInformationOfTheBookByBookIdDto("777"));
 
         assertThat(actual).isNotNull();
         assertThat(actual.getBook().getId()).isEqualTo("777");

--- a/src/test/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQueryTest.java
+++ b/src/test/java/com/myproject/doseoro/application/book/readmodel/GetAllBooksByBookIdQueryTest.java
@@ -51,9 +51,7 @@ class GetAllBooksByBookIdQueryTest {
 
         List<BookHitVO> countLikedInTheBook = new ArrayList<>();
         countLikedInTheBook.add(bookLikedList);
-
-//        FindIfBookIsLikedVo vo = new FindIfBookIsLikedVo("12312315256787", "777");
-
+        
         when(bookMybatisService.findBookByBookId("777")).thenReturn(registeredBook1);
         when(identityMybatisRepository.findUserById("12312315256787")).thenReturn(
             registeredIdentity);


### PR DESCRIPTION
### 이슈
[106] mybatis 라이브러리 의존성 제거

### 작업사항
* book, identity 도메인에 mybatis 라이브러리 의존성 제거 ex) @Param
* 내부로직이 인프라쪽 라이브러리를 의존하고 있으면 DIP 위반이기 때문에 리펙토링함.

### 테스트 사항
* 해당 책의 id에 해당 하는 책의 모든 정보를 불러온다. (수정)